### PR TITLE
feat: add upload progress and validation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/README.md
+++ b/README.md
@@ -25,3 +25,14 @@ npm install
 npm start
 ```
 Откроется на `http://localhost:3000`.
+
+### Docker
+```bash
+docker build -t dwg-backend .
+docker run -p 3001:3001 dwg-backend
+```
+
+### Особенности
+- Лимит файла: 100 МБ
+- Проверяется расширение `.dwg`
+- Веб‑форма показывает прогресс загрузки

--- a/backend/package.json
+++ b/backend/package.json
@@ -7,6 +7,7 @@
   },
   "dependencies": {
     "express": "^4.19.2",
-    "multer": "^1.4.5"
+    "multer": "^1.4.5",
+    "cors": "^2.8.5"
   }
 }

--- a/backend/server.js
+++ b/backend/server.js
@@ -1,8 +1,11 @@
 const express = require("express");
 const multer = require("multer");
+const cors = require("cors");
 
 const app = express();
 const port = 3001;
+
+app.use(cors());
 
 const upload = multer({ limits: { fileSize: 100 * 1024 * 1024 } }); // 100 MB limit
 

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -3,20 +3,44 @@ import React, { useState } from "react";
 function App() {
   const [file, setFile] = useState(null);
   const [message, setMessage] = useState("");
+  const [progress, setProgress] = useState(0);
 
-  const handleUpload = async () => {
-    if (!file) return;
+  const handleUpload = () => {
+    if (!file) {
+      setMessage("Выберите файл");
+      return;
+    }
+
+    if (!file.name.endsWith(".dwg")) {
+      setMessage("Только .dwg файлы");
+      return;
+    }
+
+    if (file.size > 100 * 1024 * 1024) {
+      setMessage("Файл больше 100 МБ");
+      return;
+    }
 
     const formData = new FormData();
     formData.append("file", file);
 
-    const res = await fetch("http://localhost:3001/api/convert", {
-      method: "POST",
-      body: formData
-    });
-
-    const data = await res.json();
-    setMessage(data.message || data.error);
+    const xhr = new XMLHttpRequest();
+    xhr.upload.onprogress = (e) => {
+      if (e.lengthComputable) {
+        setProgress(Math.round((e.loaded / e.total) * 100));
+      }
+    };
+    xhr.onload = () => {
+      const data = JSON.parse(xhr.responseText);
+      setMessage(data.message || data.error);
+      setProgress(0);
+    };
+    xhr.onerror = () => {
+      setMessage("Ошибка загрузки");
+      setProgress(0);
+    };
+    xhr.open("POST", "http://localhost:3001/api/convert");
+    xhr.send(formData);
   };
 
   return (
@@ -24,6 +48,7 @@ function App() {
       <h1>DWG → STL</h1>
       <input type="file" onChange={(e) => setFile(e.target.files[0])} />
       <button onClick={handleUpload}>Загрузить</button>
+      {progress > 0 && <progress value={progress} max="100">{progress}%</progress>}
       <p>{message}</p>
     </div>
   );


### PR DESCRIPTION
## Summary
- allow cross-origin requests on backend and enforce DWG size/type limits
- add client-side validation with upload progress bar
- document docker usage and repository features

## Testing
- `cd backend && npm test`
- `cd frontend && npm test`
- `docker build .` *(fails: command not found)*
- `node backend/server.js` *(fails: cannot find module 'express')*


------
https://chatgpt.com/codex/tasks/task_e_68ac86e12d00832eb38397f5aed05531