### PR TITLE
feat: integrate Autodesk APS STL conversion

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,8 @@
 - **Backend:** Node.js + Express
 - **Frontend:** React
 - **API:**
-  - POST `/api/convert` — принимает `.dwg`
+  - POST `/api/convert` — загружает `.dwg`, запускает конвертацию через Autodesk APS и возвращает ссылку на STL
+  - GET `/api/download/:urn/:derivativeUrn` — скачивание готового STL
   - GET `/api/status` — проверка сервиса
 
 ## Запуск локально
@@ -17,6 +18,14 @@ npm install
 npm start
 ```
 Откроется на `http://localhost:3001`.
+
+Переменные окружения:
+
+```
+APS_CLIENT_ID=<ваш client id>
+APS_CLIENT_SECRET=<ваш secret>
+APS_BUCKET=<bucket в OSS>
+```
 
 ### Frontend
 ```bash
@@ -36,3 +45,17 @@ docker run -p 3001:3001 dwg-backend
 - Лимит файла: 100 МБ
 - Проверяется расширение `.dwg`
 - Веб‑форма показывает прогресс загрузки
+- Поддерживаются STL `binary` и `ascii`
+
+### Примеры `curl`
+
+```bash
+# загрузка DWG и получение binary STL
+curl -F file=@model.dwg -F format=binary http://localhost:3001/api/convert
+
+# загрузка и получение ascii STL
+curl -F file=@model.dwg -F format=ascii http://localhost:3001/api/convert
+
+# скачивание результата после получения ссылки
+curl -o result.stl "http://localhost:3001/api/download/<urn>/<derivativeUrn>"
+```

--- a/backend/package.json
+++ b/backend/package.json
@@ -8,6 +8,8 @@
   "dependencies": {
     "express": "^4.19.2",
     "multer": "^1.4.5",
-    "cors": "^2.8.5"
+    "cors": "^2.8.5",
+    "axios": "^1.6.7",
+    "dotenv": "^16.4.5"
   }
 }

--- a/backend/server.js
+++ b/backend/server.js
@@ -1,6 +1,8 @@
 const express = require("express");
 const multer = require("multer");
 const cors = require("cors");
+const axios = require("axios");
+require("dotenv").config();
 
 const app = express();
 const port = 3001;
@@ -9,18 +11,155 @@ app.use(cors());
 
 const upload = multer({ limits: { fileSize: 100 * 1024 * 1024 } }); // 100 MB limit
 
+const { APS_CLIENT_ID, APS_CLIENT_SECRET, APS_BUCKET } = process.env;
+
+if (!APS_CLIENT_ID || !APS_CLIENT_SECRET || !APS_BUCKET) {
+  console.warn("APS credentials are not fully defined in environment variables.");
+}
+
+async function authenticate() {
+  const params = new URLSearchParams();
+  params.append("client_id", APS_CLIENT_ID);
+  params.append("client_secret", APS_CLIENT_SECRET);
+  params.append("grant_type", "client_credentials");
+  params.append("scope", "data:read data:write bucket:create bucket:read");
+  const { data } = await axios.post(
+    "https://developer.api.autodesk.com/authentication/v1/authenticate",
+    params,
+    { headers: { "Content-Type": "application/x-www-form-urlencoded" } }
+  );
+  return data.access_token;
+}
+
+async function ensureBucket(token) {
+  const bucketKey = APS_BUCKET.toLowerCase();
+  try {
+    await axios.get(
+      `https://developer.api.autodesk.com/oss/v2/buckets/${bucketKey}/details`,
+      { headers: { Authorization: `Bearer ${token}` } }
+    );
+  } catch (err) {
+    if (err.response && err.response.status === 404) {
+      await axios.post(
+        "https://developer.api.autodesk.com/oss/v2/buckets",
+        { bucketKey, policyKey: "transient" },
+        {
+          headers: {
+            Authorization: `Bearer ${token}`,
+            "Content-Type": "application/json",
+          },
+        }
+      );
+    } else {
+      throw err;
+    }
+  }
+  return bucketKey;
+}
+
+async function uploadObject(token, bucketKey, file) {
+  const objectKey = file.originalname;
+  await axios.put(
+    `https://developer.api.autodesk.com/oss/v2/buckets/${bucketKey}/objects/${encodeURIComponent(
+      objectKey
+    )}`,
+    file.buffer,
+    {
+      headers: {
+        Authorization: `Bearer ${token}`,
+        "Content-Type": "application/octet-stream",
+      },
+    }
+  );
+  return Buffer.from(`${bucketKey}/${objectKey}`)
+    .toString("base64")
+    .replace(/=/g, "");
+}
+
+async function translateToSTL(token, urn, format) {
+  await axios.post(
+    "https://developer.api.autodesk.com/modelderivative/v2/designdata/job",
+    {
+      input: { urn },
+      output: {
+        formats: [
+          {
+            type: "stl",
+            advanced: { format },
+          },
+        ],
+      },
+    },
+    {
+      headers: {
+        Authorization: `Bearer ${token}`,
+        "Content-Type": "application/json",
+      },
+    }
+  );
+}
+
+async function pollManifest(token, urn) {
+  const encodedUrn = encodeURIComponent(urn);
+  while (true) {
+    const { data } = await axios.get(
+      `https://developer.api.autodesk.com/modelderivative/v2/designdata/${encodedUrn}/manifest`,
+      { headers: { Authorization: `Bearer ${token}` } }
+    );
+    if (data.status === "success") {
+      const derivative = data.derivatives.find((d) => d.outputType === "stl");
+      if (derivative && derivative.children && derivative.children.length) {
+        return derivative.children[0].urn;
+      }
+    } else if (data.status === "failed") {
+      throw new Error("Translation failed");
+    }
+    await new Promise((r) => setTimeout(r, 5000));
+  }
+}
+
 // POST /api/convert
-app.post("/api/convert", upload.single("file"), (req, res) => {
-  if (!req.file) {
-    return res.status(400).json({ error: "Файл не загружен" });
-  }
+app.post("/api/convert", upload.single("file"), async (req, res) => {
+  try {
+    if (!req.file) {
+      return res.status(400).json({ error: "Файл не загружен" });
+    }
+    if (!req.file.originalname.endsWith(".dwg")) {
+      return res.status(400).json({ error: "Допустимы только .dwg файлы" });
+    }
 
-  if (!req.file.originalname.endsWith(".dwg")) {
-    return res.status(400).json({ error: "Допустимы только .dwg файлы" });
-  }
+    const format = req.body.format === "ascii" ? "ascii" : "binary";
 
-  // заглушка — вместо реальной конвертации
-  return res.json({ status: "ok", message: "Файл принят, конвертация в STL не реализована" });
+    const token = await authenticate();
+    const bucketKey = await ensureBucket(token);
+    const urn = await uploadObject(token, bucketKey, req.file);
+    await translateToSTL(token, urn, format);
+    const derivativeUrn = await pollManifest(token, urn);
+
+    const url = `/api/download/${encodeURIComponent(urn)}/${encodeURIComponent(
+      derivativeUrn
+    )}`;
+    return res.json({ status: "ok", url });
+  } catch (err) {
+    console.error(err);
+    return res.status(500).json({ error: "Ошибка конвертации" });
+  }
+});
+
+app.get("/api/download/:urn/:derivativeUrn", async (req, res) => {
+  try {
+    const token = await authenticate();
+    const url = `https://developer.api.autodesk.com/modelderivative/v2/designdata/${req.params.urn}/manifest/${req.params.derivativeUrn}`;
+    const response = await axios.get(url, {
+      headers: { Authorization: `Bearer ${token}` },
+      responseType: "stream",
+    });
+    res.setHeader("Content-Disposition", "attachment; filename=result.stl");
+    response.data.pipe(res);
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: "Ошибка скачивания" });
+  }
 });
 
 // GET /api/status

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -4,6 +4,8 @@ function App() {
   const [file, setFile] = useState(null);
   const [message, setMessage] = useState("");
   const [progress, setProgress] = useState(0);
+  const [format, setFormat] = useState("binary");
+  const [stlLink, setStlLink] = useState("");
 
   const handleUpload = () => {
     if (!file) {
@@ -23,6 +25,7 @@ function App() {
 
     const formData = new FormData();
     formData.append("file", file);
+    formData.append("format", format);
 
     const xhr = new XMLHttpRequest();
     xhr.upload.onprogress = (e) => {
@@ -33,11 +36,13 @@ function App() {
     xhr.onload = () => {
       const data = JSON.parse(xhr.responseText);
       setMessage(data.message || data.error);
+      setStlLink(data.url || "");
       setProgress(0);
     };
     xhr.onerror = () => {
       setMessage("Ошибка загрузки");
       setProgress(0);
+      setStlLink("");
     };
     xhr.open("POST", "http://localhost:3001/api/convert");
     xhr.send(formData);
@@ -47,8 +52,19 @@ function App() {
     <div style={{ padding: 20 }}>
       <h1>DWG → STL</h1>
       <input type="file" onChange={(e) => setFile(e.target.files[0])} />
+      <select value={format} onChange={(e) => setFormat(e.target.value)}>
+        <option value="binary">Binary STL</option>
+        <option value="ascii">ASCII STL</option>
+      </select>
       <button onClick={handleUpload}>Загрузить</button>
       {progress > 0 && <progress value={progress} max="100">{progress}%</progress>}
+      {stlLink && (
+        <p>
+          <a href={`http://localhost:3001${stlLink}`} target="_blank" rel="noreferrer">
+            Скачать STL
+          </a>
+        </p>
+      )}
       <p>{message}</p>
     </div>
   );


### PR DESCRIPTION
## Summary
- connect backend to Autodesk APS Model Derivative API
- allow choosing binary or ascii STL and stream result
- document APS env vars and example curl requests

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/axios)*
- `npm test` *(fails: Missing script: "test")*
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/tsutils)*
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_68ac881d9de4832eb87db37bf74b311c