### PR TITLE
Add frontend index and configurable API base URL

### DIFF
--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="ru">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>DWG → STL Converter</title>
+  </head>
+  <body>
+    <noscript>Для работы приложения требуется включить JavaScript.</noscript>
+    <div id="root"></div>
+  </body>
+</html>

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -7,6 +7,7 @@ function App() {
   const [format, setFormat] = useState("binary");
   const [stlLink, setStlLink] = useState("");
   const [unit, setUnit] = useState("mm");
+  const API_URL = process.env.REACT_APP_API_URL || "http://localhost:3001";
 
   const handleUpload = () => {
     if (!file) {
@@ -50,7 +51,7 @@ function App() {
       setProgress(0);
       setStlLink("");
     };
-    xhr.open("POST", "http://localhost:3001/api/convert");
+    xhr.open("POST", `${API_URL}/api/convert`);
     xhr.send(formData);
   };
 
@@ -71,7 +72,7 @@ function App() {
       {progress > 0 && <progress value={progress} max="100">{progress}%</progress>}
       {stlLink && (
         <p>
-          <button onClick={() => window.open(`http://localhost:3001${stlLink}`, "_blank")}>Скачать STL</button>
+          <button onClick={() => window.open(`${API_URL}${stlLink}`, "_blank")}>Скачать STL</button>
         </p>
       )}
       <p>{message}</p>


### PR DESCRIPTION
## Summary
- add missing `public/index.html` to render React app
- make API base URL configurable via `REACT_APP_API_URL`

## Testing
- `npm test` *(fails: vitest not found)*
- `npm install` *(fails: 403 Forbidden for @playwright/test)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ac8b00d718832e8c76bec06d5df534